### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ React component for the [moment](http://momentjs.com/) date library.
 * [Quick Start](#quick-start)
 * [Formatting](#formatting)
 * [Parsing Dates](#parsing-dates)
-* [From Now](#form-now)
+* [From Now](#from-now)
 * [From](#from)
 * [To Now](#to-now)
 * [To](#to)


### PR DESCRIPTION
Fix broken link to `From Now` section.

Note that my editor has added a missing EOL at the end of the file, by the way.