### PR TITLE
Allow any system timezone when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   "scripts": {
     "build": "npm run clean && webpack",
     "clean": "rimraf ./dist/index.js",
-    "test": "jest"
+    "test": "export TZ=America/New_York; jest"
   }
 }


### PR DESCRIPTION
Hi,

I had the same timezone issues as @nclavaud in #5.

I could think of two ways to fix the implicit UTC-5 assumption. In the first I would make all the expectations in tests/index.js honour timezones, and in the second I would just make the testing process think it's in UTC-5. I found the latter better, since it causes no changes to the tests themselves.