### PR TITLE
Replace deprecated React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",
     "rimraf": "^2.5.4",
-    "webpack": "^1.13.2"
+    "webpack": "^1.13.2",
+    "prop-types": "^15.5.8"
   },
   "jest": {
     "testRegex": "/tests/.*"

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 import React  from 'react';
 import moment from 'moment';
 import 'moment-timezone';
+import PropTypes from 'prop-types'
 
 export default class Moment extends React.Component {
     constructor(props) {
@@ -122,31 +123,31 @@ export default class Moment extends React.Component {
 }
 
 const dateTypes = [
-    React.PropTypes.string,
-    React.PropTypes.number,
-    React.PropTypes.array,
-    React.PropTypes.object
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.array,
+    PropTypes.object
 ];
 
 const parseTypes = [
-    React.PropTypes.string,
-    React.PropTypes.array
+    PropTypes.string,
+    PropTypes.array
 ];
 
 Moment.propTypes = {
-    date:       React.PropTypes.oneOfType(dateTypes),
-    parse:      React.PropTypes.oneOfType(parseTypes),
-    format:     React.PropTypes.string,
-    ago:        React.PropTypes.bool,
-    fromNow:    React.PropTypes.bool,
-    from:       React.PropTypes.oneOfType(dateTypes),
-    toNow:      React.PropTypes.bool,
-    to:         React.PropTypes.oneOfType(dateTypes),
-    calendar:   React.PropTypes.bool,
-    unix:       React.PropTypes.bool,
-    utc:        React.PropTypes.bool,
-    tz:         React.PropTypes.string,
-    locale:     React.PropTypes.string
+    date:       PropTypes.oneOfType(dateTypes),
+    parse:      PropTypes.oneOfType(parseTypes),
+    format:     PropTypes.string,
+    ago:        PropTypes.bool,
+    fromNow:    PropTypes.bool,
+    from:       PropTypes.oneOfType(dateTypes),
+    toNow:      PropTypes.bool,
+    to:         PropTypes.oneOfType(dateTypes),
+    calendar:   PropTypes.bool,
+    unix:       PropTypes.bool,
+    utc:        PropTypes.bool,
+    tz:         PropTypes.string,
+    locale:     PropTypes.string
 };
 
 Moment.defaultProps = {


### PR DESCRIPTION
No more shit like this:
`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`