### PR TITLE
Added className prop

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -50,6 +50,7 @@ export interface MomentProps {
     add?: subtractOrAddTypes,
     children?: string | number,
     style?: CSSProperties,
+    className?: string,
     filter?: (date: string) => string,
     onChange?: (content:any) => any
 }


### PR DESCRIPTION
In the other props section of the Readme (https://www.npmjs.com/package/react-moment#other-props) there is an example using className as a prop. However, className wasn't included as a prop in the MomentProps interface, so adding a className prop in a typescript project causes an error.

This adds an optional className string to the MomentProps interface, thus resolving the type error. 