### PR TITLE
Allows element prop to overwrite globalElement

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -53,7 +53,7 @@ export default class Moment extends React.Component {
   };
 
   static defaultProps = {
-    element:     'time',
+    element:     null,
     fromNow:     false,
     toNow:       false,
     calendar:    false,
@@ -74,7 +74,7 @@ export default class Moment extends React.Component {
   static globalFormat   = null;
   static globalParse    = null;
   static globalFilter   = null;
-  static globalElement  = null;
+  static globalElement  = 'time';
   static globalTimezone = null;
   static pooledElements = [];
   static pooledTimer    = null;
@@ -337,7 +337,7 @@ export default class Moment extends React.Component {
       props.title = this.getTitle();
     }
 
-    return React.createElement(Moment.globalElement || this.props.element, {
+    return React.createElement(this.props.element || Moment.globalElement, {
       dateTime: Moment.getDatetime(this.props),
       ...props
     },

--- a/tests/index.jsx
+++ b/tests/index.jsx
@@ -297,4 +297,20 @@ describe('react-moment', () => {
     );
     expect(ReactDOM.findDOMNode(date).innerHTML).toEqual('1976-04-19 09');
   });
+
+  it('globalElement', () => {
+    Moment.globalElement = 'span';
+    const date = TestUtils.renderIntoDocument(
+      <Moment parse="YYYY-MM-DD HH:mm">1976-04-19 12:59</Moment>
+    );
+    expect(ReactDOM.findDOMNode(date).tagName).toEqual('SPAN');
+  });
+
+  it('globalElement overwrite', () => {
+    Moment.globalElement = 'span';
+    const date = TestUtils.renderIntoDocument(
+      <Moment element="div" parse="YYYY-MM-DD HH:mm">1976-04-19 12:59</Moment>
+    );
+    expect(ReactDOM.findDOMNode(date).tagName).toEqual('DIV');
+  });
 });


### PR DESCRIPTION
Fixes implementation so `element` prop can overwrite `globalElement` config.

The old implementation contained code:
```javascript
return React.createElement(Moment.globalElement || this.props.element, {
```
so when `globalElement` was set it was imposible to overwrite it with `element` prop.
Suggested changes set the `defaultProps.element` to `null` and set the default value of `globalElement` to `time` which was originally the `defaultProps.element`. Eventually the order of parameters in `createElement` is swapped:
``` javascript
return React.createElement(this.props.element || Moment.globalElement, {
```

With no `globalElement` configuration the behaviour is the same as before (`time` is used globally).