### PR TITLE
Add local output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ React component for the [moment](http://momentjs.com/) date library.
     - [Duration](#duration)
     - [Duration From Now](#duration-from-now)
     - [Unix Timestamps](#unix-timestamps)
+    - [Local](#local)
     - [Timezone](#timezone)
     - [Calendar](#calendar)
     - [Locale](#locale)
@@ -533,6 +534,32 @@ Outputs:
 
 ```html
 <time>Mon Apr 19 1976 12:59:00 GMT-0500</time>
+```
+
+#### Local
+_local={bool}_
+
+Outputs the result in local time.
+
+```jsx
+import React  from 'react';
+import Moment from 'react-moment';
+
+export default class MyComponent extends React.Component {
+    render() {
+        return (
+            <Moment local>
+                2018-11-01T12:59-0500
+            </Moment>
+        );
+    }
+}
+```
+
+Outputs:
+
+```html
+<time>Thu Nov 01 2018 18:59:00 GMT+0100</time>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ Some prop values may be set globally so you don't have to set them on every reac
 * globalFilter
 * globalElement
 * globalTimezone
+* globalLocal
 
 ```jsx
 import React  from 'react';
@@ -775,6 +776,9 @@ Moment.globalFormat = 'D MMM YYYY';
 
 // Set the timezone for every instance.
 Moment.globalTimezone = 'America/Los_Angeles';
+
+// Set the output timezone for local for every instance.
+Moment.globalLocal = true;
 
 // Use a <span> tag for every react-moment instance.
 Moment.globalElement = 'span';

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -43,6 +43,7 @@ export interface MomentProps {
     decimal?: boolean,
     unix?: boolean,
     utc?: boolean,
+    local?: boolean,
     tz?: string,
     locale?: string,
     interval?: number,

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -62,6 +62,7 @@ declare class Moment extends Component<MomentProps, any> {
     constructor(props:MomentProps);
     public static globalMoment: Function;
     public static globalLocale: string;
+    public static globalLocal: boolean;
     public static globalFormat: string;
     public static globalParse: string;
     public static globalTimezone: string;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -73,6 +73,7 @@ export default class Moment extends React.Component {
 
   static globalMoment   = null;
   static globalLocale   = null;
+  static globalLocal    = null;
   static globalFormat   = null;
   static globalParse    = null;
   static globalFilter   = null;
@@ -142,11 +143,12 @@ export default class Moment extends React.Component {
    * @returns {*}
    */
   static getDatetime(props) {
-    const { utc, unix, local } = props;
-    let { date, locale, parse, tz } = props;
+    const { utc, unix } = props;
+    let { date, locale, parse, tz, local } = props;
 
     date = date || props.children;
     parse = parse || Moment.globalParse;
+    local = local || Moment.globalLocal;
     tz = tz || Moment.globalTimezone;
     if (Moment.globalLocale) {
       locale = Moment.globalLocale;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -38,6 +38,7 @@ export default class Moment extends React.Component {
     calendar:        PropTypes.oneOfType(calendarTypes),
     unix:            PropTypes.bool,
     utc:             PropTypes.bool,
+    local:           PropTypes.bool,
     tz:              PropTypes.string,
     withTitle:       PropTypes.bool,
     titleFormat:     PropTypes.string,
@@ -60,6 +61,7 @@ export default class Moment extends React.Component {
     ago:         false,
     unix:        false,
     utc:         false,
+    local:       false,
     unit:        null,
     withTitle:   false,
     decimal:     false,
@@ -140,7 +142,7 @@ export default class Moment extends React.Component {
    * @returns {*}
    */
   static getDatetime(props) {
-    const { utc, unix } = props;
+    const { utc, unix, local } = props;
     let { date, locale, parse, tz } = props;
 
     date = date || props.children;
@@ -165,6 +167,8 @@ export default class Moment extends React.Component {
     }
     if (tz) {
       datetime = datetime.tz(tz);
+    } else if (local) {
+      datetime = datetime.local();
     }
 
     return datetime;

--- a/tests/index.jsx
+++ b/tests/index.jsx
@@ -11,6 +11,20 @@ const DATE_DATE   = new Date(DATE_STRING);
 const DATE_UNIX   = DATE_DATE.getTime() / 1000;
 
 describe('react-moment', () => {
+
+  beforeEach(() => {
+    Moment.globalMoment   = null;
+    Moment.globalLocale   = null;
+    Moment.globalLocal    = null;
+    Moment.globalFormat   = null;
+    Moment.globalParse    = null;
+    Moment.globalFilter   = null;
+    Moment.globalElement  = 'time';
+    Moment.globalTimezone = null;
+    Moment.pooledElements = [];
+    Moment.pooledTimer    = null;
+  });
+
   it('children', () => {
     let date = TestUtils.renderIntoDocument(
       <Moment />
@@ -229,9 +243,17 @@ describe('react-moment', () => {
 
   it('local', () => {
     const date = TestUtils.renderIntoDocument(
-      <Moment utc local>{DATE_STRING}</Moment>
+      <Moment local>{DATE_STRING}</Moment>
     );
     const expected = moment(DATE_STRING).local().toString();
+    expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
+  });
+
+  it('utc and local', () => {
+    const date = TestUtils.renderIntoDocument(
+      <Moment utc local>{DATE_STRING}</Moment>
+    );
+    const expected = moment.utc(DATE_STRING).local().toString();
     expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
   });
 
@@ -304,6 +326,15 @@ describe('react-moment', () => {
       <Moment format="YYYY-MM-DD HH" date="1976-04-19T12:59-0500" />
     );
     expect(ReactDOM.findDOMNode(date).innerHTML).toEqual('1976-04-19 09');
+  });
+
+  it('globalLocal', () => {
+    Moment.globalLocal = true;
+    const date = TestUtils.renderIntoDocument(
+      <Moment>{DATE_STRING}</Moment>
+    );
+    const expected = moment(DATE_STRING).local().toString();
+    expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
   });
 
   it('globalElement', () => {

--- a/tests/index.jsx
+++ b/tests/index.jsx
@@ -227,6 +227,14 @@ describe('react-moment', () => {
     expect(ReactDOM.findDOMNode(date).innerHTML).toEqual('Mon Apr 19 1976 12:59:00 GMT+0000');
   });
 
+  it('local', () => {
+    const date = TestUtils.renderIntoDocument(
+      <Moment utc local>{DATE_STRING}</Moment>
+    );
+    const expected = moment(DATE_STRING).local().toString();
+    expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
+  });
+
   it('tz', () => {
     const date = TestUtils.renderIntoDocument(
       <Moment unix tz="America/Los_Angeles">{DATE_UNIX}</Moment>


### PR DESCRIPTION
This PR enables the option to output the date in `local` timestamp.
Related with https://github.com/headzoo/react-moment/issues/42