### PR TITLE
fix format for duration

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -309,7 +309,7 @@ export default class Moment extends React.Component {
 
     const fromNowPeriod = Boolean(fromNowDuring) && -datetime.diff(moment()) < fromNowDuring;
     let content  = '';
-    if (format && !fromNowPeriod) {
+    if (format && !fromNowPeriod && !(durationFromNow || duration)) {
       content = datetime.format(format);
     } else if (from) {
       content = datetime.from(from, ago);


### PR DESCRIPTION
This correctly applies format after the duration was calculated.
Previously format would always be applied first and the duration parsing would not work since it expects a number.

Fixes: #92