### PR TITLE
Update Deprecation warning: React 16.9.0 +

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -204,7 +204,7 @@ export default class Moment extends React.Component {
   /**
    * Invoked immediately before mounting occurs
    */
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.update(this.props);
   }
 
@@ -223,7 +223,7 @@ export default class Moment extends React.Component {
    *
    * @param {*} nextProps
    */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.update(nextProps);
   }
 


### PR DESCRIPTION
This quick fix should hold the line until the react team get rid of those deprecated methods (hopefully this will not happen)