### PR TITLE
fix: trim prop type declaration, added trim test

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Outputs:
 ```
 
 #### Trim
-_trim={bool}_
+_trim={string|bool}_
 
 When formatting duration time, the largest-magnitude tokens are automatically trimmed when they have no value. See the [Moment-Duration-Format docs on trim](https://github.com/jsmreese/moment-duration-format#trim) for more information.
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -24,6 +24,7 @@ type subtractOrAddTypes = {
 };
 type dateTypes = string|number|Array<string|number|object>|object;
 type calendarTypes = boolean|object;
+type trimTypes = boolean|string;
 
 export interface MomentProps {
     element?: elementTypes,
@@ -40,6 +41,7 @@ export interface MomentProps {
     diff?: dateTypes,
     duration?: dateTypes,
     durationFromNow?: boolean,
+    trim?: trimTypes,
     unit?: string,
     decimal?: boolean,
     unix?: boolean,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -21,6 +21,11 @@ const calendarTypes = [
   PropTypes.bool
 ];
 
+const trimTypes = [
+  PropTypes.string,
+  PropTypes.bool
+];
+
 export default class Moment extends React.Component {
   static propTypes = {
     element:         PropTypes.any,
@@ -47,6 +52,7 @@ export default class Moment extends React.Component {
     diff:            PropTypes.oneOfType(dateTypes),
     duration:        PropTypes.oneOfType(dateTypes),
     durationFromNow: PropTypes.bool,
+    trim:            PropTypes.oneOfType(trimTypes),
     unit:            PropTypes.string,
     decimal:         PropTypes.bool,
     filter:          PropTypes.func,
@@ -64,6 +70,7 @@ export default class Moment extends React.Component {
     local:       false,
     unit:        null,
     withTitle:   false,
+    trim:        false,
     decimal:     false,
     titleFormat: '',
     interval:    60000,

--- a/tests/index.jsx
+++ b/tests/index.jsx
@@ -140,6 +140,40 @@ describe('react-moment', () => {
     expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
   });
 
+  it('duration', () => {
+    const duration_start = moment();
+    const duration_end = moment().add(-2, 'hours');
+
+    let date = TestUtils.renderIntoDocument(
+      <Moment duration={duration_end.format()} date={duration_start.format()} />
+    );
+    let expected = moment.duration(duration_start.diff(duration_end)).format();
+    expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
+  });
+
+  it('trim', () => {
+    const duration_start = moment();
+    const duration_end = moment().add(-2, 'hour').add(-5, 'minute');
+
+    let date = TestUtils.renderIntoDocument(
+      <Moment duration={duration_end.format()} date={duration_start.format()} trim="small" />
+    );
+    let expected = moment.duration(duration_start.diff(duration_end)).format("H:mm");
+    expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
+
+    date = TestUtils.renderIntoDocument(
+      <Moment duration={duration_end.format()} date={duration_start.format()} trim="large" />
+    );
+    expected = moment.duration(duration_start.diff(duration_end)).format("H:mm:ss");
+    expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
+
+    date = TestUtils.renderIntoDocument(
+      <Moment duration={duration_end.format()} date={duration_start.format()} trim/>
+    );
+    expected = moment.duration(duration_start.diff(duration_end)).format("H:mm:ss");
+    expect(ReactDOM.findDOMNode(date).innerHTML).toEqual(expected);
+  });
+
   it('from', () => {
     let date = TestUtils.renderIntoDocument(
       <Moment from="2016-09-20T12:00">{DATE_STRING}</Moment>


### PR DESCRIPTION
added trim type declaration


fix issue where

trim was not defined in type and causing the following error

`Property 'trim' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Moment> & Readonly<PropsWithChildren<MomentProps>>'`