### PR TITLE
Adding React 18 to the `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "peerDependencies": {
     "moment": "^2.29.0",
     "prop-types": "^15.7.0",
-    "react": "^16.0 || ^17.0.0"
+    "react": "^16.0 || ^17.0.0 || ^18.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding React 18 into the mix as the dependencies were locked to v16 or v17. I got the following error when trying to install the module on a NextJS React 18 project

```
> npm install --save moment react-moment
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: personal-site-ts@0.1.0
npm ERR! Found: react@18.0.0
npm ERR! node_modules/react
npm ERR!   react@"18.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.0 || ^17.0.0" from react-moment@1.1.1
npm ERR! node_modules/react-moment
npm ERR!   react-moment@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```