### PR TITLE
fix: use `FunctionComponent` instead of `SFC` for prevent errors with React 18

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
-import { Component, ComponentClass, SFC, CSSProperties } from 'react';
+import { Component, ComponentClass, FunctionComponent, CSSProperties } from 'react';
 
-type elementTypes = string | SFC<any> | ComponentClass<any>;
+type elementTypes = string | FunctionComponent<any> | ComponentClass<any>;
 type subtractOrAddTypes = {
     years?: number,
     y?: number,
@@ -22,9 +22,9 @@ type subtractOrAddTypes = {
     milliseconds?: number,
     ms?: number
 };
-type dateTypes = string|number|Array<string|number|object>|object;
-type calendarTypes = boolean|object;
-type trimTypes = boolean|string;
+type dateTypes = string | number | Array<string | number | object> | object;
+type calendarTypes = boolean | object;
+type trimTypes = boolean | string;
 
 export interface MomentProps {
     element?: elementTypes,
@@ -58,11 +58,11 @@ export interface MomentProps {
     style?: CSSProperties,
     className?: string,
     filter?: (date: string) => string,
-    onChange?: (content:any) => any
+    onChange?: (content: any) => any
 }
 
 declare class Moment extends Component<MomentProps, any> {
-    constructor(props:MomentProps);
+    constructor(props: MomentProps);
     public static globalMoment: Function;
     public static globalLocale: string;
     public static globalLocal: boolean;


### PR DESCRIPTION
#152
I was using Vite + React 18 for update legacy code, i have the error 
```
node_modules/react-moment/dist/index.d.ts:2:37 - error TS2305: Module '"react"' has no exported member 'SFC'.
2 import { Component, ComponentClass, SFC, CSSProperties } from 'react';
```
Here my solution, comments are welcome.
Thanks.