### PR TITLE
feat: add fromNowShort prop to MomentProps interface

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -33,6 +33,7 @@ export interface MomentProps {
     format?: string,
     ago?: boolean,
     fromNow?: boolean,
+    fromNowShort?: boolean,
     fromNowDuring?: number,
     from?: dateTypes,
     toNow?: boolean,


### PR DESCRIPTION
## Summary
This PR adds the missing TypeScript type definition for the `fromNowShort` prop in the `MomentProps` interface.

## Changes
- Added `fromNowShort?: boolean` to the `MomentProps` interface in `dist/index.d.ts`

## Context
The `fromNowShort` prop was implemented in commit `1658363` (PR #166) to provide abbreviated relative time format (e.g., "2h ago" instead of "2 hours ago"), but the TypeScript type definition was missing from the declaration file.

## Impact
This change ensures TypeScript users have proper type checking and IntelliSense support when using the `fromNowShort` prop, eliminating type errors for this feature.


Issue #168 